### PR TITLE
Static arrays

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.8.2"
+julia_version = "1.8.3"
 manifest_format = "2.0"
-project_hash = "5fa8d56acde44b8c53dd8a4c65c628b23c23e98b"
+project_hash = "9f5633d7bdf97fcbab84bf234c66de2217e65649"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
@@ -622,9 +622,9 @@ uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [[deps.Qt5Base_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Fontconfig_jll", "Glib_jll", "JLLWrappers", "Libdl", "Libglvnd_jll", "OpenSSL_jll", "Pkg", "Xorg_libXext_jll", "Xorg_libxcb_jll", "Xorg_xcb_util_image_jll", "Xorg_xcb_util_keysyms_jll", "Xorg_xcb_util_renderutil_jll", "Xorg_xcb_util_wm_jll", "Zlib_jll", "xkbcommon_jll"]
-git-tree-sha1 = "c6c0f690d0cc7caddb74cef7aa847b824a16b256"
+git-tree-sha1 = "0c03844e2231e12fda4d0086fd7cbe4098ee8dc5"
 uuid = "ea2cea3b-5b76-57ae-a6ef-0a8af62496e1"
-version = "5.15.3+1"
+version = "5.15.3+2"
 
 [[deps.REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
@@ -719,9 +719,9 @@ version = "2.1.7"
 
 [[deps.StaticArrays]]
 deps = ["LinearAlgebra", "Random", "StaticArraysCore", "Statistics"]
-git-tree-sha1 = "f86b3a049e5d05227b10e15dbb315c5b90f14988"
+git-tree-sha1 = "ffc098086f35909741f71ce21d03dadf0d2bfa76"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.5.9"
+version = "1.5.11"
 
 [[deps.StaticArraysCore]]
 git-tree-sha1 = "6b7ba252635a5eff6a0b0664a41ee140a1c9e72a"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AIIncentives"
 uuid = "f37c7fce-1c0b-44d7-a749-667ab0b9ba21"
 authors = ["Mckay Jensen"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.2.0"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 julia = "1"

--- a/src/CSF.jl
+++ b/src/CSF.jl
@@ -15,14 +15,37 @@ abstract type CSF end
     p::AbstractVector{T}
 ) where {T <: Real} = proba_win(csf, i, p)
 
+# default impl of proba_win(csf, p) if only proba_win(csf, i, p) is defined
+function proba_win(csf::CSF, p::AbstractVector)
+    return proba_win.(Ref(csf), 1:length(p), Ref(p))
+end
+
 
 "Probability of i winning is p[i] / sum(p)"
 struct BasicCSF <: CSF end
 
-function proba_win(csf::BasicCSF, p::AbstractVector{T}) where {T <: Real}
+function proba_win(::BasicCSF, p::AbstractVector)
     return p ./ sum(p)
 end
 
-function proba_win(csf::BasicCSF, i::Int, p::AbstractVector{T}) where {T <: Real}
+function proba_win(::BasicCSF, i::Int, p::AbstractVector)
     return p[i] / sum(p)
+end
+
+
+"""
+Probability of i winning is w * p[i] / (1 + w * sum(p))
+Idea is that proba that someone wins is w * sum(p) / (1 + w * sum(p)),
+    and proba that i wins given someone wins is p[i] / sum(p)
+"""
+Base.@kwdef struct MaybeNoWinCSF <: CSF
+    w::Float64 = 1.0
+end
+
+function proba_win(csf::MaybeNoWinCSF, p::AbstractVector)
+    return csf.w .* p ./ (1. + csf.w * sum(p))
+end
+
+function proba_win(csf::MaybeNoWinCSF, i, p::AbstractVector)
+    return csf.w * p[i] / (1. + csf.w * sum(p))
 end

--- a/src/CostFunc.jl
+++ b/src/CostFunc.jl
@@ -1,8 +1,8 @@
 """
 Determines cost of inputs
-Subtypes should implement `cost` and `is_symmetric` and have an field `n` of type Int
+Subtypes should implement `cost` and `is_symmetric`
 """
-abstract type CostFunc end
+abstract type CostFunc{N} end
 
 function (c::CostFunc)(i::Int, Xs::AbstractVector, Xp::AbstractVector)
     return cost(c, i, Xs, Xp)
@@ -17,18 +17,16 @@ function cost(c::CostFunc, Xs, Xp)
     return cost.(Ref(c), 1:c.n, Ref(Xs), Ref(Xp))
 end
 
-mutable struct FixedUnitCost{T <: Real} <: CostFunc
-    const n::Int
-    r::Vector{T}
+mutable struct FixedUnitCost{N} <: CostFunc{N}
+    r::SVector{N, Float64}
 end
 
-function FixedUnitCost(r::Vector{T}) where {T <: Real}
-    n = length(r)
-    return FixedUnitCost(n, r)
+function FixedUnitCost(r::AbstractVector{T}) where {T <: Real}
+    return FixedUnitCost(SVector{length(r), Float64}(r))
 end
 
-function FixedUnitCost(n::Int, r::T) where T <: Real
-    return FixedUnitCost(n, fill(r, n))
+function FixedUnitCost(n::Int, r::Real)
+    return FixedUnitCost(as_SVector(r, n))
 end
 
 function cost(c::FixedUnitCost, i::Int, Xs, Xp)
@@ -47,19 +45,22 @@ end
 """
 Like FixedUnitCost but with different prices for Xs and Xp
 """
-mutable struct FixedUnitCost2{T <: Real} <: CostFunc
-    const n::Int
-    r::Matrix{T}
+mutable struct FixedUnitCost2{N} <: CostFunc{N}
+    # r has a column for each of rs and rp
+    # each row corresponds to a different player
+    r::SMatrix{N, 2, Float64}
 end
 
-function FixedUnitCost2(rs::Vector{T}, rp::Vector{T}) where {T <: Real}
+function FixedUnitCost2(rs::AbstractVector, rp::AbstractVector)
     n = length(rs)
     @assert n == length(rp) "rs and rp must have same length"
-    return FixedUnitCost2(n, [rs rp])
+    return FixedUnitCost2([as_SVector(rs, n) as_SVector(rp, n)])
 end
 
-function FixedUnitCost2(n::Int, rs::T, rp::T) where {T <: Real}
-    return FixedUnitCost2(n, repeat([rs rp], n))
+function FixedUnitCost2(n::Int, rs::Real, rp::Real)
+    rs = @SVector fill(Float64(rs), n)
+    rp = @SVector fill(Float64(rp), n)
+    return FixedUnitCost2([rs rp])
 end
 
 function cost(c::FixedUnitCost2, i::Int, Xs, Xp)
@@ -80,19 +81,22 @@ Costs change linearly in Xs, Xp
 Marginal cost of (Xs, Xp) is r0[1] + r1[1] * Xs + r0[2] + r1[2] * Xp
 => Total cost is r0[1] * Xs + r1[1] * Xs^2 / 2 + r0[2] * Xp + r1[2] * Xp^2 / 2
 """
-mutable struct LinearCost{T <: Real} <: CostFunc
-    const n::Int
-    r0::Matrix{T}
-    r1::Matrix{T}
+mutable struct LinearCost{N} <: CostFunc{N}
+    r0::SMatrix{N, 2, Float64}
+    r1::SMatrix{N, 2, Float64}
 end
 
-function LinearCost(n::Int, r0::T, r1::T) where {T <: Real}
-    return LinearCost(n, fill(r0, n, 2), fill(r1, n, 2))
+function LinearCost(n::Int, r0::Float64, r1::Float64)
+    r0 = @SMatrix fill(r0, n, 2)
+    r1 = @SMatrix fill(r1, n, 2)
+    return LinearCost(r0, r1)
 end
 
-function LinearCost(n::Int, r0::Vector{T}, r1::Vector{T}) where {T <: Real}
+# this method sets same prices for all players, but different prices for rs and rp
+# r0 and r1 should each be vectors, one entry for each of rs and rp
+function LinearCost(n::Int, r0::AbstractVector{T}, r1::AbstractVector{T}) where {T <: Real}
     @assert length(r0) == 2 && length(r1) == 2 "r0 and r1 should both have length 2 (one entry for Xs, one for Xp)"
-    return LinearCost(n, repeat(r0', 2), repeat(r1', 2))
+    return LinearCost(n, repeat(r0', n), repeat(r1', n))
 end
 
 function cost(c::LinearCost, i::Int, Xs, Xp)
@@ -111,12 +115,11 @@ end
 """
 A cost schedule where players pay a fixed unit cost r0 if their safety is less than a threshold `s_thresh` and a fixed unit cost r1 otherwise
 """
-mutable struct CertificationCost{T <: Real} <: CostFunc
-    const n::Int
-    r0::Vector{T}
-    r1::Vector{T}
-    s_thresh::Vector{T}
-    const prodFunc::ProdFunc{T}
+mutable struct CertificationCost{N} <: CostFunc{N}
+    r0::SVector{N, Float64}
+    r1::SVector{N, Float64}
+    s_thresh::SVector{N, Float64}
+    const prodFunc::ProdFunc{N}
 end
 
 """
@@ -127,13 +130,12 @@ function CertificationCost(
     r0::Real,
     r1::Real,
     s_thresh::Real,
-    prodFunc::ProdFunc{Float64},
+    prodFunc::ProdFunc,
 )
     return CertificationCost(
-        n,
-        as_Float64_Array(r0, n),
-        as_Float64_Array(r1, n),
-        as_Float64_Array(s_thresh, n),
+        as_SVector(r0, n),
+        as_SVector(r1, n),
+        as_SVector(s_thresh, n),
         prodFunc
     )
 end
@@ -145,15 +147,13 @@ function CertificationCost(
     r0::AbstractVector,
     r1::AbstractVector,
     s_thresh::AbstractVector,
-    prodFunc::ProdFunc{Float64},
-)
-    n = length(r0)
-    @assert n == length(r1) == length(s_thresh) "r0, r1, and s_thresh must have same length"
+    prodFunc::ProdFunc{N},
+) where {N}
+    @assert N == length(r0) == length(r1) == length(s_thresh) "r0, r1, and s_thresh must have same length as prodFunc's N"
     return CertificationCost(
-        n,
-        convert(Vector{Float64}, r0),
-        convert(Vector{Float64}, r1),
-        convert(Vector{Float64}, s_thresh),
+        SVector{N, Float64}(r0),
+        SVector{N, Float64}(r1),
+        SVector{N, Float64}(s_thresh),
         prodFunc
     )
 end

--- a/src/CostFunc.jl
+++ b/src/CostFunc.jl
@@ -13,8 +13,8 @@ function (c::CostFunc)(Xs::AbstractVector, Xp::AbstractVector)
 end
 
 # default impl if not implemented manually
-function cost(c::CostFunc, Xs, Xp)
-    return cost.(Ref(c), 1:c.n, Ref(Xs), Ref(Xp))
+function cost(c::CostFunc{N}, Xs, Xp) where {N}
+    return cost.(Ref(c), 1:N, Ref(Xs), Ref(Xp))
 end
 
 mutable struct FixedUnitCost{N} <: CostFunc{N}

--- a/src/ProdFunc.jl
+++ b/src/ProdFunc.jl
@@ -35,7 +35,7 @@ or, equivalently,
 ```julia
 (s, p) = prodFunc(Xs, Xp)
 ```
-where `Xs` and `Xp` are vectors of length equal to `prodFunc.n`. Here `s` and `p` will be vectors representing the safety and performance of each player. To get the safety and performance of a single player with index `i`, just do
+where `Xs` and `Xp` are vectors of length equal to N. Here `s` and `p` will be vectors representing the safety and performance of each player. To get the safety and performance of a single player with index `i`, just do
 ```julia
 (s, p) = f(prodFunc, i, xs, xp)
 ```
@@ -129,9 +129,9 @@ end
 
 (prodFunc::ProdFunc)(Xs, Xp) = f(prodFunc, Xs, Xp)
 
-function is_symmetric(prodFunc::ProdFunc)
+function is_symmetric(prodFunc::ProdFunc{N}) where {N}
     all(
-        all(x[1] .== x[2:prodFunc.n])
+        all(x[1] .== x[2:N])
         for x in (prodFunc.A, prodFunc.α, prodFunc.B, prodFunc.β, prodFunc.θ)
     )
 end

--- a/src/ProdFunc.jl
+++ b/src/ProdFunc.jl
@@ -45,13 +45,12 @@ or, equivalently,
 ```
 where `xs` and `xp` are both scalar values; the outputs `s` and `p` will also be scalar.
 """
-struct ProdFunc{T <: Real}
-    n::Int
-    A::Vector{T}
-    α::Vector{T}
-    B::Vector{T}
-    β::Vector{T}
-    θ::Vector{T}
+struct ProdFunc{N}
+    A::SVector{N, Float64}
+    α::SVector{N, Float64}
+    B::SVector{N, Float64}
+    β::SVector{N, Float64}
+    θ::SVector{N, Float64}
 end
 
 function ProdFunc(
@@ -61,37 +60,37 @@ function ProdFunc(
 )
     @assert n >= 2 "n must be at least 2"
     A = if haskey(kwargs, :A)
-        as_Float64_Array(kwargs[:A], n)
+        as_SVector(kwargs[:A], n)
     else
-        fill(10., n)
+        @SVector fill(10., n)
     end
     α = if haskey(kwargs, :α)
-        as_Float64_Array(kwargs[:α], n)
+        as_SVector(kwargs[:α], n)
     elseif haskey(kwargs, :alpha)
-        as_Float64_Array(kwargs[:alpha], n)
+        as_SVector(kwargs[:alpha], n)
     else
-        fill(0.5, n)
+        @SVector fill(0.5, n)
     end
     B = if haskey(kwargs, :B)
-        as_Float64_Array(kwargs[:B], n)
+        as_SVector(kwargs[:B], n)
     else
-        fill(10., n)
+        @SVector fill(10., n)
     end
     β = if haskey(kwargs, :β)
-        as_Float64_Array(kwargs[:β], n)
+        as_SVector(kwargs[:β], n)
     elseif haskey(kwargs, :beta)
-        as_Float64_Array(kwargs[:beta], n)
+        as_SVector(kwargs[:beta], n)
     else
-        fill(0.5, n)
+        @SVector fill(0.5, n)
     end
     θ = if haskey(kwargs, :θ)
-        as_Float64_Array(kwargs[:θ], n)
+        as_SVector(kwargs[:θ], n)
     elseif haskey(kwargs, :theta)
-        as_Float64_Array(kwargs[:theta], n)
+        as_SVector(kwargs[:theta], n)
     else
-        fill(0.25, n)
+        @SVector fill(0.25, n)
     end
-    return ProdFunc(n, A, α, B, β, θ)
+    return ProdFunc(A, α, B, β, θ)
 end
 
 ProdFunc(A, α, B, β, θ) = ProdFunc(n=length(A), A=A, α=α, B=B, β=β, θ=θ)
@@ -117,13 +116,18 @@ end
 # allow direct calling of prodFunc
 (prodFunc::ProdFunc)(i::Int, Xs::Number, Xp::Number) = f(prodFunc, i, Xs, Xp)
 
-function f(prodFunc::ProdFunc, Xs::Vector, Xp::Vector)
+
+function f(prodFunc::ProdFunc, Xs::SVector, Xp::SVector)
     p = prodFunc.B .* Xp.^prodFunc.β
     s = prodFunc.A .* Xs.^prodFunc.α .* p.^(-prodFunc.θ)
     return s, p
 end
 
-(prodFunc::ProdFunc)(Xs::Vector, Xp::Vector) = f(prodFunc, Xs, Xp)
+function f(prodFunc::ProdFunc{N}, Xs::AbstractVector, Xp::AbstractVector) where {N}
+    return f(prodFunc, SVector{N}(Xs), SVector{N}(Xp))
+end
+
+(prodFunc::ProdFunc)(Xs, Xp) = f(prodFunc, Xs, Xp)
 
 function is_symmetric(prodFunc::ProdFunc)
     all(

--- a/src/RiskFunc.jl
+++ b/src/RiskFunc.jl
@@ -21,28 +21,27 @@ Defines proba(safe) as weighted geometric mean of s / (1+s), to the nth power
 w is vector of weights
 if w is all ones, proba(safe) is simply the product of s / (1+s)
 """
-struct MultiplicativeRisk{T <: Real} <: RiskFunc
-    w::Vector{T}
-    cum_w::T  # sum of w
-    n::Int  # length of w
+struct MultiplicativeRisk{N} <: RiskFunc
+    w::SVector{N, Float64}
+    cum_w::Float64  # n / sum(w)
 end
 
 function MultiplicativeRisk(n::Int, w::T = 1.0) where {T <: Real}
     @assert n >= 2 "n must be at least 2"
-    w_ = convert(Float64, w)
-    return MultiplicativeRisk(fill(w_, n), w_, n)
+    w_ = as_SVector(w, n)
+    return MultiplicativeRisk(w_, 1. / w)
 end
 
-function MultiplicativeRisk(w::Vector{T}) where {T <: Real}
+function MultiplicativeRisk(w::AbstractVector{T}) where {T <: Real}
     n = length(w)
     @assert n >= 2 "n must be at least 2"
-    w_ = convert(Array{Float64}, w)
+    w_ = SVector{n, Float64}(w)
     return MultiplicativeRisk(w_, n / sum(w_), n)
 end
 
 function σ(
     rf::MultiplicativeRisk,
-    i::Int,
+    ::Int,
     s::AbstractVector{T}
 ) where {T <: Real}
     probas = get_probas(s)
@@ -54,36 +53,36 @@ function σ(
     s::AbstractVector{T}
 ) where {T <: Real}
     probas = get_probas(s)
-    return fill(prod(probas .* rf.w) ^ rf.cum_w, length(rf.w))
+    return @SVector fill(prod(probas .* rf.w) ^ rf.cum_w, length(rf.w))
 end
 
 
 """
-Defines proba(safe) as weighted arithmetic mean of s / (1+s)
+Defines proba(safe) as weighted arithmetic sum of s / (1+s)
 w is vector of weights
-if w is all ones, the proba(safe) is simply mean of s / (1+s)
+if w is all ones, the proba(safe) is simply sum of s / (1+s)
 """
-struct AdditiveRisk{T <: Real} <: RiskFunc
-    w::Vector{T}
+struct AdditiveRisk{N} <: RiskFunc
+    w::SVector{N, Float64}
     cum_w::T
 end
 
 function AdditiveRisk(n::Int, w::T = 1.0) where {T <: Real}
     @assert n >= 2 "n must be at least 2"
-    w_ = convert(Float64, w)
-    return AdditiveRisk(fill(w_, n), n / w_)
+    w_ = as_SVector(w, n)
+    return AdditiveRisk(w_, 1. / w)
 end
 
-function AdditiveRisk(w::Vector{T}) where {T <: Real}
+function AdditiveRisk(w::AbstractVector{T}) where {T <: Real}
     n = length(w)
     @assert n >= 2 "n must be at least 2"
-    w_ = convert(Array{Float64}, w)
+    w_ = SVector{n, Float64}(w)
     return AdditiveRisk(w_, n / sum(w_))
 end
 
 function σ(
     rf::AdditiveRisk,
-    i::Int,
+    ::Int,
     s::AbstractVector{T}
 ) where {T <: Real}
     probas = get_probas(s)
@@ -95,7 +94,7 @@ function σ(
     s::AbstractVector{T}
 ) where {T <: Real}
     probas = get_probas(s)
-    return fill(sum(probas .* rf.w) / rf.cum_w, length(rf.w))
+    return @SVector fill(sum(probas .* rf.w) / rf.cum_w, length(rf.w))
 end
 
 """

--- a/src/RiskFunc.jl
+++ b/src/RiskFunc.jl
@@ -44,7 +44,7 @@ function σ(
     ::Int,
     s::AbstractVector{T}
 ) where {T <: Real}
-    probas = get_probas(s)
+    probas = get_proba.(s)
     return prod(probas .* rf.w) ^ rf.cum_w
 end
 
@@ -52,7 +52,7 @@ function σ(
     rf::MultiplicativeRisk,
     s::AbstractVector{T}
 ) where {T <: Real}
-    probas = get_probas(s)
+    probas = get_proba.(s)
     return @SVector fill(prod(probas .* rf.w) ^ rf.cum_w, length(rf.w))
 end
 
@@ -64,7 +64,7 @@ if w is all ones, the proba(safe) is simply sum of s / (1+s)
 """
 struct AdditiveRisk{N} <: RiskFunc
     w::SVector{N, Float64}
-    cum_w::T
+    cum_w::Float64
 end
 
 function AdditiveRisk(n::Int, w::T = 1.0) where {T <: Real}
@@ -85,7 +85,7 @@ function σ(
     ::Int,
     s::AbstractVector{T}
 ) where {T <: Real}
-    probas = get_probas(s)
+    probas = get_proba.(s)
     return sum(probas .* rf.w) / rf.cum_w
 end
 
@@ -93,7 +93,7 @@ function σ(
     rf::AdditiveRisk,
     s::AbstractVector{T}
 ) where {T <: Real}
-    probas = get_probas(s)
+    probas = get_proba.(s)
     return @SVector fill(sum(probas .* rf.w) / rf.cum_w, length(rf.w))
 end
 
@@ -114,5 +114,5 @@ function σ(
     ::WinnerOnlyRisk,
     s::AbstractVector{T}
 ) where {T <: Real}
-    return get_probas(s)
+    return get_proba.(s)
 end

--- a/src/SolverResult.jl
+++ b/src/SolverResult.jl
@@ -1,14 +1,35 @@
-struct SolverResult{T <: Real}
+struct SolverResult{N}
     success::Bool
-    Xs::Vector{T}
-    Xp::Vector{T}
-    s::Vector{T}
-    p::Vector{T}
-    σ::T
-    payoffs::Vector{T}
+    Xs::SVector{N, Float64}
+    Xp::SVector{N, Float64}
+    s::SVector{N, Float64}
+    p::SVector{N, Float64}
+    σ::Float64
+    payoffs::SVector{N, Float64}
 end
 
-function prune_duplicates(results::Vector{SolverResult}; atol = 1e-6, rtol=5e-2)
+function SolverResult(
+    success::Bool,
+    Xs::AbstractVector,
+    Xp::AbstractVector,
+    s::AbstractVector,
+    p::AbstractVector,
+    σ::Real,
+    payoffs::AbstractVector,
+)
+    n = length(Xs)
+    return SolverResult(
+        success,
+        SVector{n, Float64}(Xs),
+        SVector{n, Float64}(Xp),
+        SVector{n, Float64}(s),
+        SVector{n, Float64}(p),
+        Float64(σ),
+        SVector{n, Float64}(payoffs)
+    )
+end
+
+function prune_duplicates(results::Vector{SolverResult{N}}; atol = 1e-6, rtol=5e-2) where {N}
     dups = Vector{Int}()
     unique = Vector{Int}()
     n_results = length(results)
@@ -28,11 +49,13 @@ function prune_duplicates(results::Vector{SolverResult}; atol = 1e-6, rtol=5e-2)
     return results[unique]
 end
 
-function SolverResult(problem::AbstractProblem, success::Bool, Xs::Vector{T}, Xp::Vector{T}; fill = true) where {T <: Real}
+function SolverResult(problem::AbstractProblem{N}, success::Bool, Xs::AbstractVector, Xp::AbstractVector, fill = true) where {N}
+    Xs = SVector{N, Float64}(Xs)
+    Xp = SVector{N, Float64}(Xp)
     return if fill
-        SolverResult(success, Xs, Xp, s_p_σ_payoffs(problem, Xs, Xp)...)
+        SolverResult{N}(success, Xs, Xp, s_p_σ_payoffs(problem, Xs, Xp)...)
     else
-        SolverResult(success, Xs, Xp, similar(Xs), similar(Xs), undef, similar(Xs))
+        SolverResult{N}(success, Xs, Xp, similar(Xs), similar(Xs), undef, similar(Xs))
     end
 end
 
@@ -49,9 +72,9 @@ function get_null_result(n)
 end
 
 function resolve_multiple_solutions(
-    results::Vector{SolverResult},
-    problem::Problem
-)
+    results::Vector{SolverResult{N}},
+    problem::AbstractProblem{N}
+) where {N}
     if length(results) == 1
         return results[1]
     end
@@ -66,11 +89,11 @@ function resolve_multiple_solutions(
     return results[best]
 end
 
-function resolve_multiple_solutions(results, problem::ProblemWithBeliefs)
+function resolve_multiple_solutions(results, ::ProblemWithBeliefs{N}) where {N}
     # can't distinguish between results with different beliefs
     if length(results) > 1
         println("More than one result found; equilibrium is ambiguous")
-        return get_null_result(problem.n)
+        return get_null_result(N)
     end
     return results[1]
 end

--- a/src/includes.jl
+++ b/src/includes.jl
@@ -1,5 +1,6 @@
 # import dependencies and load module components
 
+using StaticArrays
 using Optim
 using Plots
 using Plots: RecipesBase.plot

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,11 +1,23 @@
 # Utility functions, not dependent on special types, used throughout the package
 
-function as_Float64_Array(x::Union{Real, AbstractArray}, n::Int)
-    if isa(x, AbstractArray)
-        @assert length(x) == n
-        return convert(Array{Float64}, x)
-    end
-    return fill(convert(Float64, x), n)
+# Helpers for coercing to Array and SArray types
+
+function as_Float64_Array(x::Real, n::Int)
+    return fill(Float64(x), n)
+end
+
+function as_Float64_Array(x::AbstractArray, n::Int)
+    @assert length(x) == n
+    return convert(Array{Float64}, x)
+end
+
+function as_SVector(x::Real, n::Int)
+    x = Float64(x)
+    return @SVector fill(x, n)
+end
+
+function as_SVector(x::AbstractVector, n::Int)
+    return SVector{n, Float64}(x)
 end
 
 
@@ -133,9 +145,11 @@ function solve_side(
     problems = combine_params(params, base_params)
     println("$(length(problems)) problems to solve...")
     solutions = Array{SolverResult{Float64}}(undef, size(problems))
+    time0 = time()
     Threads.@threads for idx in eachindex(problems)
         solutions[idx] = solve(problems[idx]; solver_kwargs...)
     end
+    println("finished in $(time() - time0) seconds ($(1000 * (time() - time0) / length(problems)) ms per problem)")
     return solutions
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -107,19 +107,13 @@ end
 
 
 # convert from odds safe to proba safe, robust to nan & inf
-function get_proba(s::Real)
+function get_proba(s::Float64)
     proba = s / (1. + s)
     return if isnan(s) || isinf(s)
-        1::typeof(proba)
+        1.
     else
         proba
     end
-end
-
-function get_probas(s::AbstractVector{T}) where {T <: Real}
-    probas = s ./ (1. .+ s)
-    probas[isnan.(s) .| isinf.(s)] .= 1
-    return probas
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,42 +3,64 @@ using Test
 
 function test_solve()
     println("Running test on `solve.jl`...")
-    prodFunc = ProdFunc([10., 10.], [0.5, 0.5], [10., 10.], [0.5, 0.5], [0.25, 0.25])
-    riskFunc = MultiplicativeRisk(2)
-    csf = CSF(1., 0., 0., 0.)
-    problem = Problem(2, [1., 1.], [0.01, 0.01], riskFunc, prodFunc, csf)
-    options = SolverOptions(verbose = true)
+    problem = Problem()
+    
     println("With `solve_iters`:")
-    @time solve_iters_sol = solve_iters(problem, options)
-    print(solve_iters_sol)
-    println("With `solve_roots`:")
-    @time solve_roots_sol = solve_roots(problem, options)
-    print(solve_roots_sol)
+    solve(problem, method = :iters, verbose = true)
+    
     println("With `solve_mixed`:")
-    @time solve_mixed_sol = solve_mixed(problem, options)
-    print(solve_mixed_sol)
+    solve(problem, method = :mixed, verbose = true)
+    
     println("With `solve_hybrid`:")
-    @time solve_hybrid_sol = solve_hybrid(problem, options)
-    print(solve_hybrid_sol)
+    solve(problem, method = :hybrid, verbose = true)
+    
+    return
+end
+
+function test_problems()
+    println("Running test on `Problems.jl` and associated components")
+
+    println("Testing basic problem...")
+    Problem() |> solve
+
+    println("Testing problem with FixedUnitCost2...")
+    Problem(rs = 1., rp = 2.) |> solve
+
+    println("Testing problem with CertificationCost...")
+    Problem(r0 = 2., r1 = 1., s_thresh = 5) |> solve
+
+    println("Testing problem with MultiplicativeRisk...")
+    Problem(n = 3, riskFunc = MultiplicativeRisk(3)) |> solve
+
     return
 end
 
 function test_scenarios()
-    println("Running test on `scenarios.jl` + `plotting.jl`...")
+    println("Running test on `scenarios.jl`")
 
+    println("Testing basic scenario...")
     scenario = Scenario(
         n = 2,
-        α = [0.5, 0.75],
+        r = range(0.01, 0.1, length = Threads.nthreads()),
+        varying = :r
+    )
+    solve(scenario, verbose = true)
+
+    println("Testing scenario with secondary variation...")
+    scenario2 = Scenario(
+        n = 2,
         θ = [0., 0.5],
         r = range(0.01, 0.1, length = Threads.nthreads()),
+        varying = :r,
         varying2 = :θ
     )
+    solve(scenario2, verbose  = true)
 
-    @time res = solve(scenario, verbose  = true)
-    plot(res)
+    return
 end
 
 @testset "AIIncentives.jl" begin
     test_solve()
+    test_problems()
     test_scenarios()
 end


### PR DESCRIPTION
All model components now use static-sized arrays under the hood. This reduces heap allocations and gives a speed-up of nearly 2x (probably more if GC time is included). Downside is that using new n of player triggers recompilation. Set version number to 0.2.0.